### PR TITLE
Hotfix 4.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.9.1] - 2025-04-23
+
+* [PR-497](https://github.com/itk-dev/hoeringsportal/pull/497)
+  Added and configured Publish content module
+
 ## [4.9.0] - 2025-03-25
 
 * [PR-484](https://github.com/itk-dev/hoeringsportal/pull/484)
@@ -417,7 +422,8 @@ Updated drupal core 8.6.16
 
 Initial release
 
-[Unreleased]: https://github.com/itk-dev/hoeringsportal/compare/4.9.0...HEAD
+[Unreleased]: https://github.com/itk-dev/hoeringsportal/compare/4.9.1...HEAD
+[4.9.1]: https://github.com/itk-dev/hoeringsportal/compare/4.9.0...4.9.1
 [4.9.0]: https://github.com/itk-dev/hoeringsportal/compare/4.8.5...4.9.0
 [4.8.5]: https://github.com/itk-dev/hoeringsportal/compare/4.8.4...4.8.5
 [4.8.4]: https://github.com/itk-dev/hoeringsportal/compare/4.8.3...4.8.4

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "drupal/paragraphs": "^1.3",
         "drupal/pathauto": "^1.3",
         "drupal/publication_date": "^2.0",
+        "drupal/publishcontent": "^1.7",
         "drupal/quick_node_clone": "^1.12",
         "drupal/redirect": "^1.6",
         "drupal/search_api": "^1.37",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7449b8f8a5bf3fefc806edef320efeb7",
+    "content-hash": "0039bce8556991cf5882498766f76476",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4644,6 +4644,70 @@
             "homepage": "https://www.drupal.org/project/publication_date",
             "support": {
                 "source": "https://git.drupalcode.org/project/publication_date"
+            }
+        },
+        {
+            "name": "drupal/publishcontent",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/publishcontent.git",
+                "reference": "8.x-1.7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/publishcontent-8.x-1.7.zip",
+                "reference": "8.x-1.7",
+                "shasum": "01221c91ca320c7b3f40b5905ae283c473a172b0"
+            },
+            "require": {
+                "drupal/core": "^10.2 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.7",
+                    "datestamp": "1728047118",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "aaronbauman",
+                    "homepage": "https://www.drupal.org/user/384578"
+                },
+                {
+                    "name": "jacobroufa",
+                    "homepage": "https://www.drupal.org/user/168080"
+                },
+                {
+                    "name": "johnennew",
+                    "homepage": "https://www.drupal.org/user/1150042"
+                },
+                {
+                    "name": "malaussene",
+                    "homepage": "https://www.drupal.org/user/79249"
+                },
+                {
+                    "name": "rodrigoaguilera",
+                    "homepage": "https://www.drupal.org/user/408170"
+                },
+                {
+                    "name": "simon georges",
+                    "homepage": "https://www.drupal.org/user/172312"
+                }
+            ],
+            "description": "Adds a 'Publish' or 'Unpublish' link on the node edit/view pages, and a 'Publish Link' field if the Views module is enabled.",
+            "homepage": "https://www.drupal.org/project/publishcontent",
+            "support": {
+                "source": "https://git.drupalcode.org/project/publishcontent"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -86,6 +86,7 @@ module:
   path: 0
   path_alias: 0
   phpass: 0
+  publishcontent: 0
   quick_node_clone: 0
   redirect: 0
   responsive_image: 0

--- a/config/sync/publishcontent.settings.yml
+++ b/config/sync/publishcontent.settings.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: yrqqG88pLjv5VOMc9Mp665VJUyK4lMCZwg8376pI0SQ
+langcode: da
+ui_localtask: false
+ui_checkbox: true
+create_revision: false
+create_log_entry: false
+publish_text_value: Publish
+unpublish_text_value: Unpublish

--- a/config/sync/user.role.citizen_proposal_editor.yml
+++ b/config/sync/user.role.citizen_proposal_editor.yml
@@ -11,6 +11,7 @@ dependencies:
     - hoeringsportal_citizen_proposal
     - node
     - publication_date
+    - publishcontent
     - system
     - toolbar
     - view_unpublished
@@ -33,9 +34,11 @@ permissions:
   - 'edit any citizen_proposal content'
   - 'edit any webform'
   - 'edit own citizen_proposal content'
+  - 'publish any node type citizen_proposal'
   - 'revert citizen_proposal revisions'
   - 'set citizen_proposal published on date'
   - 'support citizen proposal on behalf of citizen'
+  - 'unpublish any node type citizen_proposal'
   - 'use text format email_html'
   - 'view any unpublished citizen_proposal content'
   - 'view any webform submission'


### PR DESCRIPTION
#### Link to ticket

<https://leantime.itkdev.dk/TimeTable/TimeTable?showTicketModal=4297#/tickets/showTicket/4297>

#### Description

Adds [Publish Content](https://www.drupal.org/project/publishcontent) module and lets citizen proposal editors publish citizen proposals.

> [!NOTE]
> The failing “audit” check has been fixed in https://github.com/itk-dev/hoeringsportal/pull/447 and everything will fall into place when we release and merge a lot of stuff first thing next week.
