### PR TITLE
feature/citizen proposal view II

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [4.10.0] - 2025-04-22
 
+* [PR-500](https://github.com/itk-dev/deltag.aarhus.dk/pull/500)
+  Added citizen proposal overview
 * [PR-501](https://github.com/itk-dev/deltag.aarhus.dk/pull/501)
   Updated composer packages and modules
 * [PR-492](https://github.com/itk-dev/hoeringsportal/pull/492)

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,6 @@
         "drupal/token_filter": "^2.1",
         "drupal/toolbar_visibility": "^2.1",
         "drupal/twig_tweak": "^3.2",
-        "drupal/view_custom_table": "^2.0",
         "drupal/view_unpublished": "^1.3",
         "drupal/views_data_export": "^1.3",
         "drupal/viewsreference": "^2.0@beta",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edfbf7ba7a200c26228cac9057819326",
+    "content-hash": "e5010e6213e7ed204cdec69fd887025c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5422,63 +5422,6 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/twig_tweak",
                 "issues": "https://www.drupal.org/project/issues/twig_tweak"
-            }
-        },
-        {
-            "name": "drupal/view_custom_table",
-            "version": "2.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/view_custom_table.git",
-                "reference": "2.0.8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/view_custom_table-2.0.8.zip",
-                "reference": "2.0.8",
-                "shasum": "43059f38c550ff0e33ffb946fe260fb3e891dd76"
-            },
-            "require": {
-                "drupal/core": "^10.1 || ^11"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "2.0.8",
-                    "datestamp": "1728487228",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "joseph.olstad",
-                    "homepage": "https://www.drupal.org/user/1321830"
-                },
-                {
-                    "name": "rajeshreeputra",
-                    "homepage": "https://www.drupal.org/user/3418561"
-                },
-                {
-                    "name": "sagarwani",
-                    "homepage": "https://www.drupal.org/user/3221452"
-                },
-                {
-                    "name": "sagar_cis",
-                    "homepage": "https://www.drupal.org/user/3487653"
-                }
-            ],
-            "description": "Extends views to use custom table data.",
-            "homepage": "https://www.drupal.org/project/view_custom_table",
-            "support": {
-                "source": "https://git.drupalcode.org/view_custom_table",
-                "issues": "https://www.drupal.org/project/issues/view_custom_table"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -111,7 +111,6 @@ module:
   twig_tweak: 0
   update: 0
   user: 0
-  view_custom_table: 0
   view_unpublished: 0
   views_data_export: 0
   views_ui: 0

--- a/config/sync/view_custom_table.tables.yml
+++ b/config/sync/view_custom_table.tables.yml
@@ -1,6 +1,0 @@
-hoeringsportal_citizen_proposal_support:
-  table_name: hoeringsportal_citizen_proposal_support
-  table_database: default
-  description: 'Citizen proposal support'
-  column_relations: 'a:1:{s:7:"node_id";s:4:"node";}'
-  created_by: '1'

--- a/config/sync/views.view.all_citizen_proposals.yml
+++ b/config/sync/views.view.all_citizen_proposals.yml
@@ -14,7 +14,7 @@ dependencies:
 id: all_citizen_proposals
 label: 'Alle borgerforslag'
 module: views
-description: 'En liste af alle høringer'
+description: 'En liste af alle borgerforslag'
 tag: ''
 base_table: node_field_data
 base_field: nid

--- a/config/sync/views.view.citizen_proposal.yml
+++ b/config/sync/views.view.citizen_proposal.yml
@@ -1,0 +1,533 @@
+uuid: 09b9b3ef-a817-4274-801f-6edff1acd75f
+langcode: da
+status: true
+dependencies:
+  module:
+    - csv_serialization
+    - node
+    - rest
+    - serialization
+    - user
+    - view_custom_table
+    - views_data_export
+    - xls_serialization
+id: citizen_proposal
+label: 'Citizen proposals'
+module: views
+description: ''
+tag: ''
+base_table: hoeringsportal_citizen_proposal_support
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Citizen proposals'
+      fields:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: node_id
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ID
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: node_id
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: Titel
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: true
+            path: '/node/{{ nid }}/supporters'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        id:
+          id: id
+          table: hoeringsportal_citizen_proposal_support
+          field: id
+          relationship: none
+          group_type: count
+          admin_label: ''
+          plugin_id: numeric
+          label: 'Number of supporters'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ','
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+        created_1:
+          id: created_1
+          table: node_field_data
+          field: created
+          relationship: node_id
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: field
+          label: 'Authored on'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: custom
+            custom_date_format: 'Y-m-d H:i:s'
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Antal elementer'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- Alle -'
+            offset: false
+            offset_label: Forskydning
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Udfør
+          reset_button: false
+          reset_button_label: Gendan
+          exposed_sorts_label: 'Sortér efter'
+          expose_sort_order: true
+          sort_asc_label: Stigende
+          sort_desc_label: Faldende
+      access:
+        type: perm
+        options:
+          perm: 'edit any citizen_proposal content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          plugin_id: text_custom
+      sorts: {  }
+      arguments: {  }
+      filters: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            nid: nid
+            title: title
+            id: id
+            created_1: created_1
+          default: created_1
+          info:
+            nid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created_1:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        node_id:
+          id: node_id
+          table: hoeringsportal_citizen_proposal_support
+          field: node_id
+          relationship: none
+          group_type: group
+          admin_label: 'Node id'
+          plugin_id: standard
+          required: false
+      group_by: true
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  data_export_1:
+    id: data_export_1
+    display_title: 'Data export (CSV)'
+    display_plugin: data_export
+    position: 2
+    display_options:
+      empty: {  }
+      style:
+        type: data_export
+        options:
+          formats:
+            csv: csv
+          csv_settings:
+            delimiter: ','
+            enclosure: '"'
+            escape_char: \
+            strip_tags: true
+            trim: true
+            encoding: utf8
+            utf8_bom: '0'
+            use_serializer_encode_only: false
+      defaults:
+        empty: false
+      display_description: ''
+      display_extenders: {  }
+      path: admin/citizen-proposal/export
+      displays:
+        page_1: page_1
+        default: '0'
+      filename: 'deltag-citizen-proposal-[date:raw].csv'
+      automatic_download: true
+      store_in_public_file_directory: false
+      custom_redirect_path: false
+      redirect_to_display: none
+      include_query_params: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - request_format
+        - user.permissions
+      tags: {  }
+  data_export_2:
+    id: data_export_2
+    display_title: 'Data export (XLSX)'
+    display_plugin: data_export
+    position: 2
+    display_options:
+      empty: {  }
+      style:
+        type: data_export
+        options:
+          formats:
+            xlsx: xlsx
+          csv_settings:
+            delimiter: ','
+            enclosure: '"'
+            escape_char: \
+            strip_tags: true
+            trim: true
+            encoding: utf8
+            utf8_bom: '0'
+            use_serializer_encode_only: false
+      defaults:
+        empty: false
+      display_description: ''
+      display_extenders: {  }
+      path: admin/citizen-proposal/export
+      displays:
+        page_1: page_1
+        default: '0'
+      filename: 'deltag-citizen-proposal-[date:raw].xlsx'
+      automatic_download: true
+      store_in_public_file_directory: false
+      custom_redirect_path: false
+      redirect_to_display: none
+      include_query_params: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - request_format
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      empty: {  }
+      defaults:
+        empty: false
+      display_extenders: {  }
+      path: admin/citizen-proposal
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/config/sync/views.view.citizen_proposal.yml
+++ b/config/sync/views.view.citizen_proposal.yml
@@ -324,7 +324,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'edit any citizen_proposal content'
+          perm: 'administer citizen proposal'
       cache:
         type: tag
         options: {  }

--- a/config/sync/views.view.citizen_proposal.yml
+++ b/config/sync/views.view.citizen_proposal.yml
@@ -108,8 +108,8 @@ display:
           alter:
             alter_text: false
             text: ''
-            make_link: true
-            path: '/node/{{ nid }}/supporters'
+            make_link: false
+            path: ''
             absolute: false
             external: false
             replace_spaces: false
@@ -147,7 +147,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: false
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -171,8 +171,8 @@ display:
           alter:
             alter_text: false
             text: ''
-            make_link: false
-            path: ''
+            make_link: true
+            path: '/node/{{ nid }}/supporters'
             absolute: false
             external: false
             replace_spaces: false

--- a/config/sync/views.view.citizen_proposal.yml
+++ b/config/sync/views.view.citizen_proposal.yml
@@ -4,11 +4,11 @@ status: true
 dependencies:
   module:
     - csv_serialization
+    - hoeringsportal_citizen_proposal
     - node
     - rest
     - serialization
     - user
-    - view_custom_table
     - views_data_export
     - xls_serialization
 id: citizen_proposal
@@ -401,7 +401,7 @@ display:
           field: node_id
           relationship: none
           group_type: group
-          admin_label: 'Node id'
+          admin_label: 'Citizen proposal'
           plugin_id: standard
           required: false
       group_by: true

--- a/config/sync/views.view.citizen_proposal_support.yml
+++ b/config/sync/views.view.citizen_proposal_support.yml
@@ -271,7 +271,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'edit any citizen_proposal content'
+          perm: 'administer citizen proposal'
       cache:
         type: tag
         options: {  }

--- a/config/sync/views.view.citizen_proposal_support.yml
+++ b/config/sync/views.view.citizen_proposal_support.yml
@@ -4,11 +4,11 @@ status: true
 dependencies:
   module:
     - csv_serialization
+    - hoeringsportal_citizen_proposal
     - node
     - rest
     - serialization
     - user
-    - view_custom_table
     - views_data_export
     - xls_serialization
 id: citizen_proposal_support
@@ -382,9 +382,9 @@ display:
           field: node_id
           relationship: none
           group_type: group
-          admin_label: 'Node id'
+          admin_label: 'Citizen proposal'
           plugin_id: standard
-          required: true
+          required: false
       header:
         result:
           id: result

--- a/web/modules/custom/hoeringsportal_citizen_proposal/hoeringsportal_citizen_proposal.info.yml
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/hoeringsportal_citizen_proposal.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^8.8 || ^9 || ^10
 dependencies:
   - twig_tweak:twig_tweak
   - drupal:symfony_mailer
+  - drupal:views

--- a/web/modules/custom/hoeringsportal_citizen_proposal/hoeringsportal_citizen_proposal.links.task.yml
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/hoeringsportal_citizen_proposal.links.task.yml
@@ -1,6 +1,11 @@
-hoeringsportal_citizen_proposal.admin:
-  title: 'Citizen proposal'
-  route_name: hoeringsportal_citizen_proposal.proposal_admin
+hoeringsportal_citizen_proposal.citizen_proposals:
+  title: 'Citizen proposals'
+  route_name: view.citizen_proposal.page_1
+  base_route: system.admin_content
+
+hoeringsportal_citizen_proposal.admin_settings:
+  title: 'Citizen proposal settings'
+  route_name: hoeringsportal_citizen_proposal.proposal_admin_settings
   base_route: system.admin_content
 
 hoeringsportal_citizen_proposal.proposal_list:

--- a/web/modules/custom/hoeringsportal_citizen_proposal/hoeringsportal_citizen_proposal.module
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/hoeringsportal_citizen_proposal.module
@@ -68,3 +68,10 @@ function hoeringsportal_citizen_proposal_page_attachments(array &$page) {
 function hoeringsportal_citizen_proposal_node_presave(EntityInterface $entity) {
   Drupal::service(Helper::class)->nodeEntityPresave($entity);
 }
+
+/**
+ * Implements hook_views_data().
+ */
+function hoeringsportal_citizen_proposal_views_data() {
+  return Drupal::service(Helper::class)->viewsData();
+}

--- a/web/modules/custom/hoeringsportal_citizen_proposal/hoeringsportal_citizen_proposal.routing.yml
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/hoeringsportal_citizen_proposal.routing.yml
@@ -26,8 +26,8 @@ hoeringsportal_citizen_proposal.citizen_proposal.proposal_approve:
     # so we disable caching here (https://www.drupal.org/docs/drupal-apis/routing-system/structure-of-routes).
     no_cache: TRUE
 
-hoeringsportal_citizen_proposal.proposal_admin:
-  path: '/admin/citizen_proposal'
+hoeringsportal_citizen_proposal.proposal_admin_settings:
+  path: '/admin/citizen_proposal/settings'
   defaults:
     _form: '\Drupal\hoeringsportal_citizen_proposal\Form\ProposalAdminForm'
     _title: 'Administer citizen proposal'

--- a/web/modules/custom/hoeringsportal_citizen_proposal/src/Helper/Helper.php
+++ b/web/modules/custom/hoeringsportal_citizen_proposal/src/Helper/Helper.php
@@ -522,4 +522,167 @@ class Helper implements LoggerAwareInterface {
     return $node->field_vote_end->date->getTimestamp();
   }
 
+  /**
+   * Implements hook_views_data().
+   */
+  public function viewsData(): array {
+    return [
+      // Make our custom table available for views.
+      'hoeringsportal_citizen_proposal_support' => [
+        'table' => [
+          'group' => $this->t('Citizen proposal'),
+          'provider' => 'hoeringsportal_citizen_proposal',
+          'base' => [
+            'field' => 'id',
+            'title' => $this->t('Citizen proposal support'),
+            'help' => $this->t('Citizen proposal support related to citizen proposal nodes'),
+          ],
+        ],
+
+        'id' => [
+          'title' => $this->t('Id'),
+          'help' => $this->t('Citizen proposal support'),
+          'field' => [
+            'id' => 'numeric',
+          ],
+          'sort' => [
+            'id' => 'standard',
+          ],
+          'filter' => [
+            'id' => 'numeric',
+          ],
+          'argument' => [
+            'id' => 'numeric',
+          ],
+        ],
+
+        'node_id' => [
+          'title' => $this->t('Citizen proposal'),
+          'help' => $this->t('Citizen proposal'),
+          'field' => [
+            'id' => 'numeric',
+          ],
+          'sort' => [
+            'id' => 'standard',
+          ],
+          'filter' => [
+            'id' => 'numeric',
+          ],
+          'argument' => [
+            'id' => 'numeric',
+          ],
+          'relationship' => [
+            'base' => 'node_field_data',
+            'id' => 'standard',
+            'base field' => 'nid',
+            'label' => $this->t('Citizen proposal'),
+          ],
+        ],
+
+        'user_identifier' => [
+          'title' => $this->t('User identifier'),
+          'help' => $this->t('User identifier'),
+          'field' => [
+            'id' => 'standard',
+          ],
+          'sort' => [
+            'id' => 'standard',
+          ],
+          'filter' => [
+            'id' => 'string',
+          ],
+          'argument' => [
+            'id' => 'string',
+          ],
+        ],
+
+        'user_name' => [
+          'title' => $this->t('User name'),
+          'help' => $this->t('User name'),
+          'field' => [
+            'id' => 'standard',
+          ],
+          'sort' => [
+            'id' => 'standard',
+          ],
+          'filter' => [
+            'id' => 'string',
+          ],
+          'argument' => [
+            'id' => 'string',
+          ],
+        ],
+
+        'user_email' => [
+          'title' => $this->t('User email'),
+          'help' => $this->t('User email'),
+          'field' => [
+            'id' => 'standard',
+          ],
+          'sort' => [
+            'id' => 'standard',
+          ],
+          'filter' => [
+            'id' => 'string',
+          ],
+          'argument' => [
+            'id' => 'string',
+          ],
+        ],
+
+        'allow_email' => [
+          'title' => $this->t('Allow email'),
+          'help' => $this->t('Allow email'),
+          'field' => [
+            'id' => 'numeric',
+          ],
+          'sort' => [
+            'id' => 'standard',
+          ],
+          'filter' => [
+            'id' => 'numeric',
+          ],
+          'argument' => [
+            'id' => 'numeric',
+          ],
+        ],
+
+        'created' => [
+          'title' => $this->t('Created'),
+          'help' => $this->t('Created'),
+          'field' => [
+            'id' => 'numeric',
+          ],
+          'sort' => [
+            'id' => 'standard',
+          ],
+          'filter' => [
+            'id' => 'numeric',
+          ],
+          'argument' => [
+            'id' => 'numeric',
+          ],
+        ],
+      ],
+
+      // @todo Set up a reverse relation.
+      'node' => [
+        'hoeringsportal_citizen_proposal_support' => [
+          'title' => $this->t('Citizen proposal support (title)'),
+          'help' => $this->t('Citizen proposal support (help)'),
+          'relationship' => [
+            'group' => $this->t('Citizen proposal support (group)'),
+            'id' => 'entity_reverse',
+            'field_name' => 'hoeringsportal_citizen_proposal_support',
+            'field table' => 'hoeringsportal_citizen_proposal_support',
+            'field field' => 'node_id',
+            'base' => 'node_field_data',
+            'base field' => 'nid',
+            'label' => $this->t('Citizen proposal support (relationship)'),
+          ],
+        ],
+      ],
+    ];
+  }
+
 }


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/TimeTable/TimeTable?showTicketModal=4333#/tickets/showTicket/4333

#### Description

* Fixes a typo (https://github.com/itk-dev/deltag.aarhus.dk/pull/500/commits/c12e3c11ed1ed55131ee4568b5dd91e2ecd73efb)
* Adds citizen proposal overview (view) with count of supporters. Caveat: I'd like to show all citizen proposals, but currently the view shows only proposal with at least one supporter. Some more `hook_views_data` tricks are needed to make this work.
* Removes the [Views Custom Table module](https://www.drupal.org/project/view_custom_table) and implements (some)`hook_views_data` tricks to make custom table data available for views

#### Screenshot of the result

![Screenshot 2025-04-28 at 16 04 32](https://github.com/user-attachments/assets/1ce6f40e-1fa4-4de0-ae9a-514b952de761)

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
